### PR TITLE
build: explicitly use openjdk8 on travis linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,9 @@ before_install:
       # skip brew update
       export HOMEBREW_NO_AUTO_UPDATE=1
       brew cask uninstall java; brew tap AdoptOpenJDK/openjdk; brew cask install adoptopenjdk8;
+    else
+      PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//');
+      JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64;
     fi
   # Accept licenses before installing components, no need to echo y for each component
   - yes | sdkmanager --licenses


### PR DESCRIPTION
Travis continues moving things around as they deal with Oracle turning JDK8 into a pay-to-play deal