### PR TITLE
Allow running using a glob pattern to match files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,32 @@
 const { fork } = require('child_process');
 const { join } = require('path');
-const { getClassesMapping, readDir, chunk } = require('./src/utils');
+const commander = require('commander');
+const glob = require('glob');
+const { getClassesMapping, getFilesList, chunk } = require('./src/utils');
 
 const cpus = require('os').cpus().length;
 
-const arg = process.argv.slice(2)[0];
-const mode = arg && ((arg === 'reverse') || (arg === '-r')) ? 'reverse' : 'forward';
-const SEARCH_DIR = 'node_modules';
+commander
+  .option('-r, --reverse', 'Run Jetifier in reverse mode', false)
+  .option('-g, --glob <glob>', 'Glob pattern to run Jetifier on', 'node_modules/**/*');
+
+commander.parse(process.argv);
+
+const mode = commander.reverse ? 'reverse' : 'forward';
 
 const classesMapping = getClassesMapping();
-const files = readDir(SEARCH_DIR);
 
-console.log(`Jetifier found ${files.length} file(s) to ${mode}-jetify. Using ${cpus} workers...`);
+glob(commander.glob, { nodir: true }, function (err, files) {
+  if (err)
+    throw err;
 
-for (const filesChunk of chunk(files, cpus)) {
-  const worker = fork(join(__dirname, 'src', 'worker.js'));
-  worker.send({ filesChunk, classesMapping, mode });
-}
+  const filesList = getFilesList(files);
+
+  console.log(`Jetifier found ${filesList.length} file(s) to ${mode}-jetify. Using ${cpus} workers...`);
+
+  for (const filesChunk of chunk(filesList, cpus)) {
+    const worker = fork(join(__dirname, 'src', 'worker.js'));
+    worker.send({ filesChunk, classesMapping, mode });
+  }
+});
+

--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
   "homepage": "https://github.com/mikehardy/jetifier#readme",
   "devDependencies": {
     "np": "^5.1.3"
+  },
+  "dependencies": {
+    "commander": "^4.1.1",
+    "glob": "^7.1.6"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,16 +10,17 @@ const chunk = (array, chunkSize) => {
   return result;
 };
 
-const readDir = (dir, filesList = []) => {
-  const files = readdirSync(dir);
-  for (let file of files) {
-    const filePath = join(dir, file);
+const getFilesList = (globFiles, filesList = []) => {
+  const cwd = process.cwd();
+
+  for (let file of globFiles) {
+    const filePath = join(cwd, file);
     if (lstatSync(filePath).isSymbolicLink()) {
       continue;
     }
     if (existsSync(filePath)) {
       if (statSync(filePath).isDirectory()) {
-        filesList = readDir(filePath, filesList);
+        filesList = getFilesList(filePath, filesList);
       }
       else {
         if (file.endsWith('.java') || file.endsWith('.xml') || file.endsWith('.kt')) {
@@ -68,6 +69,6 @@ const getClassesMapping = () => {
 
 module.exports = {
   getClassesMapping,
-  readDir,
+  getFilesList,
   chunk
 };


### PR DESCRIPTION
Hello!

I had a need to run jetify selectively on certain node_modules only while leaving others untouched. Seeing as the library doesn't support this out of the box yet, I went ahead with implementing this in a fork where I picked up files to jetify using a glob and this has served my use case pretty well. I just noticed #39 and wasn't sure if this is the direction that was expected but I thought I'd submit the version I'm currently using in case it was.

There seems to be another PR that does implement similar functionality but I didn't go through it fully since it seems to be doing a lot in a single change and hasn't been updated in a while.

I tried to keep the changes minimal and introduced a dependency on commander.js as I personally dislike parsing arguments manually. Another benefit is an out-of-the-box `jetify --help` display.