### PR TITLE
fix: traverse node_modules up to '/' to work with monorepo structures

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
 const { fork } = require('child_process');
 const { join } = require('path');
-const { getClassesMapping, readDir, chunk } = require('./src/utils');
+const { getClassesMapping, traverseNodeModules, readDir, chunk } = require('./src/utils');
 
 const cpus = require('os').cpus().length;
 
 const arg = process.argv.slice(2)[0];
 const mode = arg && ((arg === 'reverse') || (arg === '-r')) ? 'reverse' : 'forward';
-const SEARCH_DIR = 'node_modules';
 
 const classesMapping = getClassesMapping();
-const files = readDir(SEARCH_DIR);
+const files = [];
+traverseNodeModules(process.cwd(), searchDir => {
+  readDir(searchDir, files);
+});
 
 console.log(`Jetifier found ${files.length} file(s) to ${mode}-jetify. Using ${cpus} workers...`);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,17 @@ const chunk = (array, chunkSize) => {
   return result;
 };
 
+const traverseNodeModules = (startPath, visitFn) => {
+  const nmPath = join(startPath, 'node_modules');
+  if (existsSync(nmPath)) {
+    visitFn(nmPath);
+  }
+  const upperDir = join(startPath, "../");
+  if (upperDir !== startPath) {
+    traverseNodeModules(join(startPath, "../"), visitFn);
+  }
+}
+
 const readDir = (dir, filesList = []) => {
   const files = readdirSync(dir);
   for (let file of files) {
@@ -68,6 +79,7 @@ const getClassesMapping = () => {
 
 module.exports = {
   getClassesMapping,
+  traverseNodeModules,
   readDir,
   chunk
 };


### PR DESCRIPTION
A typical monorepo structure:

```text
- ProjectRoot
  - node_modules
  - package.json
  - packages
    - react-native-app-1
      - node_modules (may not exist if hoisted)
      - package.json
    - react-native-app-2
      - node_modules (may not exist if hoisted)
      - package.json
```

Currently we only search the node_modules in the current working directory. If we run `npx jetifier` in `react-native-app-1` dir, it will not modify `ProjectRoot/node_modules`.

But for monorepo setups, we usually hoist all child node_modules to project root. i.e. Neither `node_modules` exists in `react-native-app-1` nor `react-native-app-2`. Since jetifier is included in `react-native-community/cli`, when we run `react-native run android` in `react-native-app-1`, the cli crashed because `jetifer` throw an exception if `node_modules` doesn't exist.

```text
info Running jetifier to migrate libraries to AndroidX. You can disable it using "--no-jetifier" flag.
internal/fs/utils.js:259
    throw err;
    ^

Error: ENOENT: no such file or directory, scandir 'node_modules'
    at readdirSync (fs.js:974:3)
    at readDir (/Users/stackia/Repositories/Mindhand/jetifier/src/utils.js:14:17)
    at Object.<anonymous> (/Users/stackia/Repositories/Mindhand/jetifier/index.js:12:15)
    ... {
  errno: -2,
  syscall: 'scandir',
  code: 'ENOENT',
  path: 'node_modules'
}
error Failed to run jetifier. Run CLI with --verbose flag for more details.
```

The only workaround I found is to disable jetifer with `--no-jetifer` param, which apparently may break the android build.

---

This PR makes jetifer traverse all node_modules from cwd up to the root to work with monorepo setups, and solves https://github.com/mikehardy/jetifier/issues/36.

Manually tested on both macOS and Windows.
