### PR TITLE
Remove Node 8, add RN61/RN62, Add Node12/14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,25 +12,26 @@ matrix:
   fast_finish: true
   include:
     - os: osx
-      osx_image: xcode10.2
-      env: RNVERSION=59 NODE=8
-    - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.5
       env: RNVERSION=59 NODE=10
     - os: osx
-      osx_image: xcode10.2
-      env: RNVERSION=60 NODE=11
+      osx_image: xcode11.5
+      env: RNVERSION=60 NODE=12
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.5
       env: RNVERSION=60 NODE=node
     - os: linux
-      env: RNVERSION=59 NODE=11
+      env: RNVERSION=60 NODE=10
+    - os: linux
+      env: RNVERSION=61 NODE=12
+    - os: linux
+      env: RNVERSION=62 NODE=12
+    - os: linux
+      env: RNVERSION=62 NODE=14
+    - os: linux
+      env: RNVERSION=59 NODE=12
     - os: linux
       env: RNVERSION=59 NODE=node
-    - os: linux
-      env: RNVERSION=60 NODE=8
-    - os: linux
-      env: RNVERSION=60 NODE=10
   allow_failures:
     - env: RNVERSION=60 NODE=node
 


### PR DESCRIPTION
Expanding the Travis matrix on this one since Node and react-native has moved on.
It still all works! Forwards and reverse, from RN59 to RN62 and Node 10 through 14.
Kind of amazing.